### PR TITLE
Ability to define button custom class

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,16 @@ import 'rc-swipeout/assets/index.less';
     {
       text: 'reply',
       onPress:() => console.log('reply'),
-      style: { backgroundColor: 'orange', color: 'white' }
+      style: { backgroundColor: 'orange', color: 'white' },
+      cls: 'custom-class-1'
     }
   ]}
   right={[
     {
       text: 'delete',
       onPress:() => console.log('delete'),
-      style: { backgroundColor: 'red', color: 'white' }
+      style: { backgroundColor: 'red', color: 'white' },
+      cls: 'custom-class-2'
     }
   ]}
   onOpen={() => console.log('open')}
@@ -95,6 +97,7 @@ import Swipeout from 'rc-swipeout/lib'
 | text       | button text     | String | `Click` |
 | style       | button style     | Object | `` |
 | onPress       | button press function      | Function | `function() {}` |
+| cls       | button custom class     | String | `` |
 
 ## Test Case
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ import 'rc-swipeout/assets/index.less';
       text: 'reply',
       onPress:() => console.log('reply'),
       style: { backgroundColor: 'orange', color: 'white' },
-      cls: 'custom-class-1'
+      className: 'custom-class-1'
     }
   ]}
   right={[
@@ -58,7 +58,7 @@ import 'rc-swipeout/assets/index.less';
       text: 'delete',
       onPress:() => console.log('delete'),
       style: { backgroundColor: 'red', color: 'white' },
-      cls: 'custom-class-2'
+      className: 'custom-class-2'
     }
   ]}
   onOpen={() => console.log('open')}
@@ -97,7 +97,7 @@ import Swipeout from 'rc-swipeout/lib'
 | text       | button text     | String | `Click` |
 | style       | button style     | Object | `` |
 | onPress       | button press function      | Function | `function() {}` |
-| cls       | button custom class     | String | `` |
+| className       | button custom class     | String | `` |
 
 ## Test Case
 

--- a/src/Swipeout.web.js
+++ b/src/Swipeout.web.js
@@ -181,7 +181,7 @@ class Swipeout extends React.Component {
         {buttons.map((btn, i) => {
           return (
             <div key={i}
-              className={`${prefixCls}-btn ${btn.hasOwnProperty('cls') ? btn.cls : ''}`}
+              className={`${prefixCls}-btn ${btn.hasOwnProperty('className') ? btn.className : ''}`}
               style={btn.style}
               onClick={(e) => this.onBtnClick(e, btn)}
             >

--- a/src/Swipeout.web.js
+++ b/src/Swipeout.web.js
@@ -181,7 +181,7 @@ class Swipeout extends React.Component {
         {buttons.map((btn, i) => {
           return (
             <div key={i}
-              className={`${prefixCls}-btn`}
+              className={`${prefixCls}-btn ${btn.hasOwnProperty('cls') ? btn.cls : ''}`}
               style={btn.style}
               onClick={(e) => this.onBtnClick(e, btn)}
             >


### PR DESCRIPTION
Hi folks, it would be nice to be able to define custom class for each button. I know you can define inline styles, but classes are more concise and organized IMO.

```
{
  text: 'reply',
  onPress:() => console.log('reply'),
  style: { backgroundColor: 'orange', color: 'white' },
  cls: 'custom-class-1'
}
```
