### PR TITLE
fix removeEventListener bug

### DIFF
--- a/src/Swipeout.tsx
+++ b/src/Swipeout.tsx
@@ -54,7 +54,7 @@ class Swipeout extends React.Component <SwipeoutPropType, any> {
   }
 
   componentWillUnmount() {
-    document.body.removeEventListener('touchstart', this.onCloseSwipe);
+    document.body.removeEventListener('touchstart', this.onCloseSwipe, true);
   }
 
   onCloseSwipe(ev) {


### PR DESCRIPTION
Registration event monitoring is used in the event capture mode.
But did not specify the pattern when destroyed.