### PR TITLE
当一根手机在SwipeOut元素上滑动时可以正常触发onPanStart, onPanMove，但在一根手指滑动的过程中如果再加一根手指进…

### DIFF
--- a/src/Swipeout.tsx
+++ b/src/Swipeout.tsx
@@ -241,6 +241,7 @@ export default class Swipeout extends React.Component <SwipeoutPropType, any> {
           onPanStart={this.onPanStart}
           onPanMove={this.onPanMove}
           onPanEnd={this.onPanEnd}
+          onPanCancel={this.onPanEnd}
           onSwipeLeft={this.doOpenRight}
           onSwipeRight={this.doOpenLeft}
           direction="horizontal"


### PR DESCRIPTION
…来一起滑动并一起离开屏幕，那么滑动的界面会卡在只有一根手指滑动时的画面，无法再滑动（此时left或者right展示部分，没有open），更严重的是如果按钮没有设置autoClose，便再也无法复原初始状态，设置了的话可以通过点击按钮复原。其中原因就是因为gesture中checkIfSingleTouchMove检测到两根手指变不再会执行onPanEnd，只会执行onPancancel，所以需要格外设置onPanCancel.

when you touch one finger on the SwipeOut and move your finger , it will trigger onPanStart and onPanMove and works fine, but when you put another finger on and move  meanwhile, and suddenly move out your two finger, the SwipeOut will get stucked, and can't be swiped anymore, especilly when you don't set autoClose, it will not go back to the initial state anymore except to reload.  The reason is that when gesture's function checkIfSingleTouchMove detectd multifinger and will not trigger onPanEnd anymore , instead it trigger onPanCancel, so we need to set onPanCancel additionally.
fix bug when swipeout can't trigger onPanEnd, and swipeout can't  work normally anymore.