### PR TITLE
fix: 修复 this.btnsLeftWidth 和 this.btnsRightWidth 值

### DIFF
--- a/src/Swipeout.tsx
+++ b/src/Swipeout.tsx
@@ -52,8 +52,10 @@ export default class Swipeout extends React.Component <SwipeoutPropType, any> {
   }
 
   componentDidMount() {
-    this.btnsLeftWidth = this.left ? this.left.offsetWidth : 0;
-    this.btnsRightWidth = this.right ? this.right.offsetWidth : 0;
+    setTimeout(() => {
+        this.btnsLeftWidth = this.left ? this.left.offsetWidth : 0;
+        this.btnsRightWidth = this.right ? this.right.offsetWidth : 0;
+    }, 300);
     document.body.addEventListener('touchstart', this.onCloseSwipe, true);
   }
 


### PR DESCRIPTION
修复 this.btnsLeftWidth 和 this.btnsRightWidth 在未渲染完成的情况下拿到错误的 offsetWidth 值